### PR TITLE
ci: enforce security bats suite in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,8 @@ jobs:
           git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
           sudo /tmp/bats-core/install.sh /usr/local
 
-      - name: Run tests
+      - name: Run core bats tests
         run: bats tests/maw_test.bats
+
+      - name: Run security bats tests
+        run: bats tests/security_test.bats


### PR DESCRIPTION
## Summary
- split the test workflow test step into explicit core and security bats steps
- keep existing trigger and dependency setup unchanged
- enforce running `tests/security_test.bats` in CI for every push/PR to `main`

## Changes
- `.github/workflows/test.yml`
  - `Run core bats tests`: `bats tests/maw_test.bats`
  - `Run security bats tests`: `bats tests/security_test.bats`

## Verification
- `bats tests/maw_test.bats` (167 passed / 0 failed)
- `bats tests/security_test.bats` (24 passed / 0 failed)
- `rg -n "tests/security_test\\.bats" .github/workflows/test.yml`

Closes #2