### PR TITLE
ci: enforce doctor multi-mode check in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run security bats tests
         run: bats tests/security_test.bats
+
+      - name: Run doctor multi mode check
+        run: ./bin/maw doctor --json --exit-code-mode multi


### PR DESCRIPTION
## 変更内容
- `.github/workflows/test.yml` に `Run doctor multi mode check` を追加
- コマンド: `./bin/maw doctor --json --exit-code-mode multi`
- 実行順: core bats -> security bats -> doctor multi

## 検証
- `./bin/maw doctor --json --exit-code-mode multi` 実行時 exit=0
- local環境での `bats tests/maw_test.bats` / `bats tests/security_test.bats` は本実行環境でハングしてタイムアウトしたため、実行結果として `CI上での3ステップ実行` に委譲（後続でActions再実行）
- 変更対象は `.github/workflows/test.yml` のみ

Closes #4