### PR TITLE
A-003: add tracked operational handover samples

### DIFF
--- a/reports/evaluation/2026-03-08-handover-samples.json
+++ b/reports/evaluation/2026-03-08-handover-samples.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-03-08T13:39:21Z",
+  "generated_at": "2026-03-12T04:59:08Z",
   "mode": "handover_samples",
   "samples": [
     {
@@ -9,7 +9,7 @@
       "summary": "Issue 10 T2 docs: fixed the public doctor --json contract in commands and CI docs, including a new English doctor-ci guide",
       "evidence_refs_count": 4,
       "verification_status": "skipped",
-      "source_ref": ".maw/handovers/ws-issue10_t2_docs.json"
+      "source_ref": "reports/evaluation/handovers/ws-issue10_t2_docs.json"
     },
     {
       "id": "ws-issue10_t3_pr",
@@ -17,7 +17,7 @@
       "summary": "T3: froze the typed blocked_by contract in commands docs, validate_handover_bundle, and regression tests while keeping legacy read compatibility.",
       "evidence_refs_count": 3,
       "verification_status": "passed",
-      "source_ref": ".maw/handovers/ws-issue10_t3_pr.json"
+      "source_ref": "reports/evaluation/handovers/ws-issue10_t3_pr.json"
     },
     {
       "id": "ws-issue10_t6_pr",
@@ -25,7 +25,7 @@
       "summary": "Phase1 proxy metrics script added and PR #18 opened; direct script smoke checks passed, but bats stalled in bats-preprocess in this shell.",
       "evidence_refs_count": 3,
       "verification_status": "skipped",
-      "source_ref": ".maw/handovers/ws-issue10_t6_pr.json"
+      "source_ref": "reports/evaluation/handovers/ws-issue10_t6_pr.json"
     }
   ],
   "notes": [

--- a/reports/evaluation/2026-03-08-handover-samples.json
+++ b/reports/evaluation/2026-03-08-handover-samples.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "generated_at": "2026-03-08T13:39:21Z",
+  "mode": "handover_samples",
+  "samples": [
+    {
+      "id": "ws-issue10_t2_docs",
+      "workspace": "issue10_t2_docs",
+      "summary": "Issue 10 T2 docs: fixed the public doctor --json contract in commands and CI docs, including a new English doctor-ci guide",
+      "evidence_refs_count": 4,
+      "verification_status": "skipped",
+      "source_ref": ".maw/handovers/ws-issue10_t2_docs.json"
+    },
+    {
+      "id": "ws-issue10_t3_pr",
+      "workspace": "issue10_t3_pr",
+      "summary": "T3: froze the typed blocked_by contract in commands docs, validate_handover_bundle, and regression tests while keeping legacy read compatibility.",
+      "evidence_refs_count": 3,
+      "verification_status": "passed",
+      "source_ref": ".maw/handovers/ws-issue10_t3_pr.json"
+    },
+    {
+      "id": "ws-issue10_t6_pr",
+      "workspace": "issue10_t6_pr",
+      "summary": "Phase1 proxy metrics script added and PR #18 opened; direct script smoke checks passed, but bats stalled in bats-preprocess in this shell.",
+      "evidence_refs_count": 3,
+      "verification_status": "skipped",
+      "source_ref": ".maw/handovers/ws-issue10_t6_pr.json"
+    }
+  ],
+  "notes": [
+    "Operationally derived handover samples promoted into tracked evaluation artifacts.",
+    "Tracked samples are stable projections with non-empty summary and at least one evidence_refs entry."
+  ]
+}

--- a/reports/evaluation/2026-03-08-handover-samples.md
+++ b/reports/evaluation/2026-03-08-handover-samples.md
@@ -1,0 +1,53 @@
+# Handover Samples (2026-03-08)
+
+Operationally derived handover samples promoted into tracked evaluation artifacts.
+Tracked copies intentionally exclude volatile fields such as claims, raw logs, and raw diffs.
+
+| sample | workspace | verification_status | evidence_refs | notes |
+| --- | --- | --- | ---: | --- |
+| ws-issue10_t2_docs | issue10_t2_docs | skipped | 4 | summary/evidence_refs present |
+| ws-issue10_t3_pr | issue10_t3_pr | passed | 3 | summary/evidence_refs present |
+| ws-issue10_t6_pr | issue10_t6_pr | skipped | 3 | summary/evidence_refs present |
+
+## ws-issue10_t2_docs
+
+Workspace: issue10_t2_docs
+
+Summary: Issue 10 T2 docs: fixed the public doctor --json contract in commands and CI docs, including a new English doctor-ci guide
+
+Evidence refs:
+- docs:docs/ja/commands.md
+- docs:docs/en/commands.md
+- docs:docs/ja/doctor-ci.md
+- docs:docs/en/doctor-ci.md
+
+Verification status: skipped
+
+
+## ws-issue10_t3_pr
+
+Workspace: issue10_t3_pr
+
+Summary: T3: froze the typed blocked_by contract in commands docs, validate_handover_bundle, and regression tests while keeping legacy read compatibility.
+
+Evidence refs:
+- test:bats tests/maw_test.bats --filter blocked_by|takeover --format plan|handover --validate|migrate handover
+- test:bats tests/maw_test.bats --filter validate_handover_bundle|resolved
+- test:bats tests/maw_test.bats
+
+Verification status: passed
+
+
+## ws-issue10_t6_pr
+
+Workspace: issue10_t6_pr
+
+Summary: Phase1 proxy metrics script added and PR #18 opened; direct script smoke checks passed, but bats stalled in bats-preprocess in this shell.
+
+Evidence refs:
+- diff:34c75c9
+- pr:#18
+- test:scripts/phase1_metrics.sh | jq
+
+Verification status: skipped
+

--- a/reports/evaluation/handovers/ws-issue10_t2_docs.json
+++ b/reports/evaluation/handovers/ws-issue10_t2_docs.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "workspace": "issue10_t2_docs",
+  "branch": "worker/issue-10-issue10_t2_docs",
+  "agent": "worker",
+  "state": "clean",
+  "summary": "Issue 10 T2 docs: fixed the public doctor --json contract in commands and CI docs, including a new English doctor-ci guide",
+  "evidence_refs": [
+    "docs:docs/ja/commands.md",
+    "docs:docs/en/commands.md",
+    "docs:docs/ja/doctor-ci.md",
+    "docs:docs/en/doctor-ci.md"
+  ],
+  "verification_status": "skipped",
+  "blocked_by": []
+}

--- a/reports/evaluation/handovers/ws-issue10_t3_pr.json
+++ b/reports/evaluation/handovers/ws-issue10_t3_pr.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "workspace": "issue10_t3_pr",
+  "branch": "worker/issue-10-issue10_t3_pr",
+  "agent": "worker",
+  "state": "clean",
+  "summary": "T3: froze the typed blocked_by contract in commands docs, validate_handover_bundle, and regression tests while keeping legacy read compatibility.",
+  "evidence_refs": [
+    "test:bats tests/maw_test.bats --filter blocked_by|takeover --format plan|handover --validate|migrate handover",
+    "test:bats tests/maw_test.bats --filter validate_handover_bundle|resolved",
+    "test:bats tests/maw_test.bats"
+  ],
+  "verification_status": "passed",
+  "blocked_by": []
+}

--- a/reports/evaluation/handovers/ws-issue10_t6_pr.json
+++ b/reports/evaluation/handovers/ws-issue10_t6_pr.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "workspace": "issue10_t6_pr",
+  "branch": "codex/issue-10-issue10_t6_pr",
+  "agent": "codex",
+  "state": "clean",
+  "summary": "Phase1 proxy metrics script added and PR #18 opened; direct script smoke checks passed, but bats stalled in bats-preprocess in this shell.",
+  "evidence_refs": [
+    "diff:34c75c9",
+    "pr:#18",
+    "test:scripts/phase1_metrics.sh | jq"
+  ],
+  "verification_status": "skipped",
+  "blocked_by": []
+}

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -90,6 +90,15 @@ fail() {
   exit 1
 }
 
+dir_has_all_samples() {
+  local dir="$1"
+  local sample=""
+  for sample in "${SAMPLE_FILES[@]}"; do
+    [[ -f "${dir}/${sample}" ]] || return 1
+  done
+  return 0
+}
+
 resolve_source_dir() {
   if [[ -n "${SOURCE_DIR}" ]]; then
     case "${SOURCE_DIR}" in
@@ -109,14 +118,14 @@ resolve_source_dir() {
   fi
 
   local operational_source_dir="${REPO_ROOT}/.maw/handovers"
-  if [[ -d "${operational_source_dir}" ]]; then
+  if [[ -d "${operational_source_dir}" ]] && dir_has_all_samples "${operational_source_dir}"; then
     SOURCE_DIR="${operational_source_dir}"
     SOURCE_REF_PREFIX=".maw/handovers"
     return 0
   fi
 
   local tracked_source_dir="${REPO_ROOT}/reports/evaluation/handovers"
-  if [[ -d "${tracked_source_dir}" ]]; then
+  if [[ -d "${tracked_source_dir}" ]] && dir_has_all_samples "${tracked_source_dir}"; then
     SOURCE_DIR="${tracked_source_dir}"
     SOURCE_REF_PREFIX="reports/evaluation/handovers"
     return 0

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+OUTPUT_DATE="$(date +"%Y-%m-%d")"
+OUTPUT_DIR="${REPO_ROOT}/reports/evaluation"
+
+SAMPLE_FILES=(
+  "ws-issue10_t2_docs.json"
+  "ws-issue10_t3_pr.json"
+  "ws-issue10_t6_pr.json"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: phase1_handover_samples.sh [--output-dir <dir>] [--date <YYYY-MM-DD>]
+
+Promote operational handover JSON samples into tracked evaluation artifacts.
+
+Options:
+  --output-dir <dir>   Directory for generated evaluation artifacts (default: reports/evaluation)
+  --date <YYYY-MM-DD>  Override artifact filename date (default: current local date)
+  -h, --help           Show this help
+EOF
+}
+
+require_tools() {
+  local tool=""
+  for tool in jq cp mkdir; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+      echo "missing required tool: ${tool}" >&2
+      exit 1
+    fi
+  done
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --output-dir)
+        [[ $# -ge 2 ]] || {
+          echo "--output-dir requires a value" >&2
+          exit 1
+        }
+        OUTPUT_DIR="$2"
+        shift 2
+        ;;
+      --date)
+        [[ $# -ge 2 ]] || {
+          echo "--date requires a value" >&2
+          exit 1
+        }
+        if [[ ! "$2" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+          echo "invalid --date value: $2" >&2
+          exit 1
+        fi
+        OUTPUT_DATE="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+find_handover_source_dir() {
+  local candidate="${REPO_ROOT}"
+
+  while [[ "${candidate}" != "/" ]]; do
+    if [[ -d "${candidate}/.maw/handovers" ]]; then
+      printf '%s\n' "${candidate}/.maw/handovers"
+      return 0
+    fi
+    candidate="$(dirname "${candidate}")"
+  done
+
+  fail "could not locate .maw/handovers from ${REPO_ROOT}"
+}
+
+validate_source_handover() {
+  local json_file="$1"
+  local rel_ref="$2"
+
+  jq -e '
+    type == "object" and
+    (.summary | type == "string") and
+    (.summary != "") and
+    (.evidence_refs | type == "array") and
+    ((.evidence_refs | length) >= 1) and
+    (.workspace | type == "string") and
+    (.workspace != "") and
+    (.verification_status | type == "string")
+  ' "${json_file}" >/dev/null 2>&1 || fail "invalid handover sample: ${rel_ref}"
+}
+
+project_tracked_handover() {
+  local json_file="$1"
+
+  jq '{
+    version,
+    workspace,
+    branch,
+    agent,
+    state,
+    summary,
+    evidence_refs,
+    verification_status,
+    blocked_by
+  }' "${json_file}"
+}
+
+copy_sample_files() {
+  local source_dir="$1"
+  local target_dir="$2"
+  local sample=""
+
+  mkdir -p "${target_dir}"
+
+  for sample in "${SAMPLE_FILES[@]}"; do
+    local source_file="${source_dir}/${sample}"
+    [[ -f "${source_file}" ]] || fail "missing handover sample: ${source_file}"
+    validate_source_handover "${source_file}" ".maw/handovers/${sample}"
+    project_tracked_handover "${source_file}" > "${target_dir}/${sample}"
+  done
+}
+
+build_summary_json() {
+  local handover_dir="$1"
+  local sample_entries="[]"
+  local sample=""
+
+  for sample in "${SAMPLE_FILES[@]}"; do
+    local tracked_file="${handover_dir}/${sample}"
+    local workspace
+    local summary
+    local evidence_refs_count
+    local verification_status
+
+    workspace="$(jq -r '.workspace' "${tracked_file}")"
+    summary="$(jq -r '.summary' "${tracked_file}")"
+    evidence_refs_count="$(jq '.evidence_refs | length' "${tracked_file}")"
+    verification_status="$(jq -r '.verification_status' "${tracked_file}")"
+
+    sample_entries="$(
+      jq -n \
+        --arg id "${sample%.json}" \
+        --arg workspace "${workspace}" \
+        --arg summary "${summary}" \
+        --argjson evidence_refs_count "${evidence_refs_count}" \
+        --arg verification_status "${verification_status}" \
+        --arg source_ref ".maw/handovers/${sample}" \
+        --argjson current "${sample_entries}" \
+        '$current + [{
+          id: $id,
+          workspace: $workspace,
+          summary: $summary,
+          evidence_refs_count: $evidence_refs_count,
+          verification_status: $verification_status,
+          source_ref: $source_ref
+        }]' \
+        
+    )"
+  done
+
+  jq -n \
+    --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --arg note1 "Operationally derived handover samples promoted into tracked evaluation artifacts." \
+    --arg note2 "Tracked samples are stable projections with non-empty summary and at least one evidence_refs entry." \
+    --argjson samples "${sample_entries}" \
+    '{
+      version: 1,
+      generated_at: $generated_at,
+      mode: "handover_samples",
+      samples: $samples,
+      notes: [$note1, $note2]
+    }'
+}
+
+write_markdown_report() {
+  local summary_json="$1"
+  local handover_dir="$2"
+  local md_path="$3"
+  local sample=""
+
+  {
+    printf '# Handover Samples (%s)\n\n' "${OUTPUT_DATE}"
+    printf 'Operationally derived handover samples promoted into tracked evaluation artifacts.\n'
+    printf 'Tracked copies intentionally exclude volatile fields such as claims, raw logs, and raw diffs.\n\n'
+    printf '| sample | workspace | verification_status | evidence_refs | notes |\n'
+    printf '| --- | --- | --- | ---: | --- |\n'
+
+    jq -r '
+      .samples[]
+      | "| \(.id) | \(.workspace) | \(.verification_status) | \(.evidence_refs_count) | summary/evidence_refs present |"
+    ' <<<"${summary_json}"
+
+    for sample in "${SAMPLE_FILES[@]}"; do
+      local tracked_file="${handover_dir}/${sample}"
+      printf '\n## %s\n\n' "${sample%.json}"
+      jq -r '
+        "Workspace: \(.workspace)\n\nSummary: \(.summary)\n\nEvidence refs:\n" +
+        (.evidence_refs | map("- " + .) | join("\n")) +
+        "\n\nVerification status: \(.verification_status)"
+      ' "${tracked_file}"
+      printf '\n'
+    done
+  } > "${md_path}"
+}
+
+main() {
+  require_tools
+  parse_args "$@"
+
+  local source_dir
+  local handover_output_dir
+  local summary_json
+  local summary_json_path
+  local summary_md_path
+
+  source_dir="$(find_handover_source_dir)"
+  handover_output_dir="${OUTPUT_DIR}/handovers"
+  summary_json_path="${OUTPUT_DIR}/${OUTPUT_DATE}-handover-samples.json"
+  summary_md_path="${OUTPUT_DIR}/${OUTPUT_DATE}-handover-samples.md"
+
+  mkdir -p "${OUTPUT_DIR}"
+  copy_sample_files "${source_dir}" "${handover_output_dir}"
+
+  summary_json="$(build_summary_json "${handover_output_dir}")"
+  printf '%s\n' "${summary_json}" > "${summary_json_path}"
+  write_markdown_report "${summary_json}" "${handover_output_dir}" "${summary_md_path}"
+
+  printf '%s\n' "${summary_json}"
+}
+
+main "$@"

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -102,7 +102,7 @@ resolve_source_dir() {
         SOURCE_REF_PREFIX="${SOURCE_DIR#${REPO_ROOT}/}"
         ;;
       *)
-        SOURCE_REF_PREFIX="$(basename "$(dirname "${SOURCE_DIR}")")/$(basename "${SOURCE_DIR}")"
+        SOURCE_REF_PREFIX="${SOURCE_DIR}"
         ;;
     esac
     return 0
@@ -184,6 +184,14 @@ copy_sample_files() {
     local tmp_file="${staging_dir}/${sample}.tmp"
     [[ -f "${source_file}" ]] || fail "missing handover sample: ${source_file}"
     validate_source_handover "${source_file}" "${SOURCE_REF_PREFIX}/${sample}"
+    local expected_workspace="${sample#ws-}"
+    expected_workspace="${expected_workspace%.json}"
+    local actual_workspace
+    actual_workspace="$(jq -r '.workspace' "${source_file}")"
+    if [[ "${actual_workspace}" != "${expected_workspace}" ]]; then
+      rm -rf "${staging_dir}"
+      fail "workspace mismatch in ${sample}: expected '${expected_workspace}', got '${actual_workspace}'"
+    fi
     project_tracked_handover "${source_file}" > "${tmp_file}"
     mv "${tmp_file}" "${staging_dir}/${sample}"
   done

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -90,6 +90,10 @@ fail() {
 
 resolve_source_dir() {
   if [[ -n "${SOURCE_DIR}" ]]; then
+    case "${SOURCE_DIR}" in
+      /*) ;;
+      *) SOURCE_DIR="${REPO_ROOT}/${SOURCE_DIR}" ;;
+    esac
     [[ -d "${SOURCE_DIR}" ]] || fail "source dir not found: ${SOURCE_DIR}"
     case "${SOURCE_DIR}" in
       "${REPO_ROOT}"/*)

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -103,7 +103,24 @@ dir_validates_all_samples() {
   local dir="$1"
   local sample=""
   for sample in "${SAMPLE_FILES[@]}"; do
-    validate_handover_bundle "${dir}/${sample}" >/dev/null 2>&1 || return 1
+    local file="${dir}/${sample}"
+    validate_handover_bundle "${file}" >/dev/null 2>&1 || return 1
+    jq -e '
+      type == "object" and
+      (.version | type == "number" and . == floor and . >= 2) and
+      (.branch | type == "string" and . != "") and
+      (.agent | type == "string" and . != "") and
+      (.state | type == "string" and . != "") and
+      (.summary | type == "string" and . != "") and
+      (.evidence_refs | type == "array" and length >= 1) and
+      all(.evidence_refs[]; type == "string" and . != "") and
+      (.workspace | type == "string" and . != "") and
+      (.verification_status | type == "string" and . != "") and
+      (if has("blocked_by") then
+        (.blocked_by | type == "array") and
+        all(.blocked_by[]; type == "string" or (type == "object" and (.type | . == "blocker" or . == "dependency" or . == "issue")))
+      else true end)
+    ' "${file}" >/dev/null 2>&1 || return 1
   done
   return 0
 }

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -94,7 +94,7 @@ resolve_source_dir() {
   if [[ -n "${SOURCE_DIR}" ]]; then
     case "${SOURCE_DIR}" in
       /*) ;;
-      *) SOURCE_DIR="${REPO_ROOT}/${SOURCE_DIR}" ;;
+      *) SOURCE_DIR="$(cd "${SOURCE_DIR}" && pwd)" || fail "source dir not found: ${SOURCE_DIR}" ;;
     esac
     [[ -d "${SOURCE_DIR}" ]] || fail "source dir not found: ${SOURCE_DIR}"
     case "${SOURCE_DIR}" in
@@ -133,7 +133,7 @@ validate_source_handover() {
 
   jq -e '
     type == "object" and
-    (.version | type == "number") and
+    (.version | type == "number" and . == floor and . > 0) and
     (.branch | type == "string") and
     (.branch != "") and
     (.agent | type == "string") and

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -6,6 +6,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 OUTPUT_DATE="$(date +"%Y-%m-%d")"
 OUTPUT_DIR="${REPO_ROOT}/reports/evaluation"
+SOURCE_DIR=""
+SOURCE_REF_PREFIX=""
 
 SAMPLE_FILES=(
   "ws-issue10_t2_docs.json"
@@ -15,13 +17,14 @@ SAMPLE_FILES=(
 
 usage() {
   cat <<'EOF'
-Usage: phase1_handover_samples.sh [--output-dir <dir>] [--date <YYYY-MM-DD>]
+Usage: phase1_handover_samples.sh [--output-dir <dir>] [--date <YYYY-MM-DD>] [--source-dir <dir>]
 
 Promote operational handover JSON samples into tracked evaluation artifacts.
 
 Options:
   --output-dir <dir>   Directory for generated evaluation artifacts (default: reports/evaluation)
   --date <YYYY-MM-DD>  Override artifact filename date (default: current local date)
+  --source-dir <dir>   Directory containing source handover JSON files
   -h, --help           Show this help
 EOF
 }
@@ -59,6 +62,14 @@ parse_args() {
         OUTPUT_DATE="$2"
         shift 2
         ;;
+      --source-dir)
+        [[ $# -ge 2 ]] || {
+          echo "--source-dir requires a value" >&2
+          exit 1
+        }
+        SOURCE_DIR="$2"
+        shift 2
+        ;;
       -h|--help)
         usage
         exit 0
@@ -77,12 +88,33 @@ fail() {
   exit 1
 }
 
-find_handover_source_dir() {
+resolve_source_dir() {
+  if [[ -n "${SOURCE_DIR}" ]]; then
+    [[ -d "${SOURCE_DIR}" ]] || fail "source dir not found: ${SOURCE_DIR}"
+    case "${SOURCE_DIR}" in
+      "${REPO_ROOT}"/*)
+        SOURCE_REF_PREFIX="${SOURCE_DIR#${REPO_ROOT}/}"
+        ;;
+      *)
+        SOURCE_REF_PREFIX="$(basename "$(dirname "${SOURCE_DIR}")")/$(basename "${SOURCE_DIR}")"
+        ;;
+    esac
+    return 0
+  fi
+
+  local tracked_source_dir="${REPO_ROOT}/reports/evaluation/handovers"
+  if [[ -d "${tracked_source_dir}" ]]; then
+    SOURCE_DIR="${tracked_source_dir}"
+    SOURCE_REF_PREFIX="reports/evaluation/handovers"
+    return 0
+  fi
+
   local candidate="${REPO_ROOT}"
 
   while [[ "${candidate}" != "/" ]]; do
     if [[ -d "${candidate}/.maw/handovers" ]]; then
-      printf '%s\n' "${candidate}/.maw/handovers"
+      SOURCE_DIR="${candidate}/.maw/handovers"
+      SOURCE_REF_PREFIX=".maw/handovers"
       return 0
     fi
     candidate="$(dirname "${candidate}")"
@@ -97,13 +129,22 @@ validate_source_handover() {
 
   jq -e '
     type == "object" and
+    (.version | type == "number") and
+    (.branch | type == "string") and
+    (.branch != "") and
+    (.agent | type == "string") and
+    (.agent != "") and
+    (.state | type == "string") and
+    (.state != "") and
     (.summary | type == "string") and
     (.summary != "") and
     (.evidence_refs | type == "array") and
     ((.evidence_refs | length) >= 1) and
+    all(.evidence_refs[]; type == "string") and
     (.workspace | type == "string") and
     (.workspace != "") and
-    (.verification_status | type == "string")
+    (.verification_status | type == "string") and
+    (.blocked_by | type == "array")
   ' "${json_file}" >/dev/null 2>&1 || fail "invalid handover sample: ${rel_ref}"
 }
 
@@ -132,9 +173,11 @@ copy_sample_files() {
 
   for sample in "${SAMPLE_FILES[@]}"; do
     local source_file="${source_dir}/${sample}"
+    local tmp_file="${target_dir}/${sample}.tmp"
     [[ -f "${source_file}" ]] || fail "missing handover sample: ${source_file}"
-    validate_source_handover "${source_file}" ".maw/handovers/${sample}"
-    project_tracked_handover "${source_file}" > "${target_dir}/${sample}"
+    validate_source_handover "${source_file}" "${SOURCE_REF_PREFIX}/${sample}"
+    project_tracked_handover "${source_file}" > "${tmp_file}"
+    mv "${tmp_file}" "${target_dir}/${sample}"
   done
 }
 
@@ -156,23 +199,21 @@ build_summary_json() {
     verification_status="$(jq -r '.verification_status' "${tracked_file}")"
 
     sample_entries="$(
-      jq -n \
+      jq \
         --arg id "${sample%.json}" \
         --arg workspace "${workspace}" \
         --arg summary "${summary}" \
         --argjson evidence_refs_count "${evidence_refs_count}" \
         --arg verification_status "${verification_status}" \
-        --arg source_ref ".maw/handovers/${sample}" \
-        --argjson current "${sample_entries}" \
-        '$current + [{
+        --arg source_ref "${SOURCE_REF_PREFIX}/${sample}" \
+        '. + [{
           id: $id,
           workspace: $workspace,
           summary: $summary,
           evidence_refs_count: $evidence_refs_count,
           verification_status: $verification_status,
           source_ref: $source_ref
-        }]' \
-        
+        }]' <<<"${sample_entries}"
     )"
   done
 
@@ -231,7 +272,8 @@ main() {
   local summary_json_path
   local summary_md_path
 
-  source_dir="$(find_handover_source_dir)"
+  resolve_source_dir
+  source_dir="${SOURCE_DIR}"
   handover_output_dir="${OUTPUT_DIR}/handovers"
   summary_json_path="${OUTPUT_DIR}/${OUTPUT_DATE}-handover-samples.json"
   summary_md_path="${OUTPUT_DIR}/${OUTPUT_DATE}-handover-samples.md"

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -142,7 +142,7 @@ validate_source_handover() {
 
   jq -e '
     type == "object" and
-    (.version | type == "number" and . == floor and . > 0) and
+    (.version | type == "number" and . == floor and . >= 2) and
     (.branch | type == "string") and
     (.branch != "") and
     (.agent | type == "string") and

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -164,7 +164,7 @@ project_tracked_handover() {
     summary,
     evidence_refs,
     verification_status,
-    blocked_by
+    blocked_by: (.blocked_by // [])
   }' "${json_file}"
 }
 

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -99,6 +99,15 @@ dir_has_all_samples() {
   return 0
 }
 
+dir_validates_all_samples() {
+  local dir="$1"
+  local sample=""
+  for sample in "${SAMPLE_FILES[@]}"; do
+    validate_handover_bundle "${dir}/${sample}" >/dev/null 2>&1 || return 1
+  done
+  return 0
+}
+
 resolve_source_dir() {
   if [[ -n "${SOURCE_DIR}" ]]; then
     case "${SOURCE_DIR}" in
@@ -118,7 +127,7 @@ resolve_source_dir() {
   fi
 
   local operational_source_dir="${REPO_ROOT}/.maw/handovers"
-  if [[ -d "${operational_source_dir}" ]] && dir_has_all_samples "${operational_source_dir}"; then
+  if [[ -d "${operational_source_dir}" ]] && dir_has_all_samples "${operational_source_dir}" && dir_validates_all_samples "${operational_source_dir}"; then
     SOURCE_DIR="${operational_source_dir}"
     SOURCE_REF_PREFIX=".maw/handovers"
     return 0
@@ -160,7 +169,7 @@ validate_source_handover() {
     (.verification_status != "") and
     (if has("blocked_by") then
       (.blocked_by | type == "array") and
-      all(.blocked_by[]; type == "string" or type == "object")
+      all(.blocked_by[]; type == "string" or (type == "object" and (.type | . == "blocker" or . == "dependency" or . == "issue")))
     else true end)
   ' "${json_file}" >/dev/null 2>&1 || fail "invalid handover sample: ${rel_ref}"
 }

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -106,13 +106,6 @@ resolve_source_dir() {
     return 0
   fi
 
-  local tracked_source_dir="${REPO_ROOT}/reports/evaluation/handovers"
-  if [[ -d "${tracked_source_dir}" ]]; then
-    SOURCE_DIR="${tracked_source_dir}"
-    SOURCE_REF_PREFIX="reports/evaluation/handovers"
-    return 0
-  fi
-
   local candidate="${REPO_ROOT}"
 
   while [[ "${candidate}" != "/" ]]; do
@@ -123,6 +116,13 @@ resolve_source_dir() {
     fi
     candidate="$(dirname "${candidate}")"
   done
+
+  local tracked_source_dir="${REPO_ROOT}/reports/evaluation/handovers"
+  if [[ -d "${tracked_source_dir}" ]]; then
+    SOURCE_DIR="${tracked_source_dir}"
+    SOURCE_REF_PREFIX="reports/evaluation/handovers"
+    return 0
+  fi
 
   fail "could not locate .maw/handovers from ${REPO_ROOT}"
 }

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -106,16 +106,12 @@ resolve_source_dir() {
     return 0
   fi
 
-  local candidate="${REPO_ROOT}"
-
-  while [[ "${candidate}" != "/" ]]; do
-    if [[ -d "${candidate}/.maw/handovers" ]]; then
-      SOURCE_DIR="${candidate}/.maw/handovers"
-      SOURCE_REF_PREFIX=".maw/handovers"
-      return 0
-    fi
-    candidate="$(dirname "${candidate}")"
-  done
+  local operational_source_dir="${REPO_ROOT}/.maw/handovers"
+  if [[ -d "${operational_source_dir}" ]]; then
+    SOURCE_DIR="${operational_source_dir}"
+    SOURCE_REF_PREFIX=".maw/handovers"
+    return 0
+  fi
 
   local tracked_source_dir="${REPO_ROOT}/reports/evaluation/handovers"
   if [[ -d "${tracked_source_dir}" ]]; then
@@ -144,7 +140,7 @@ validate_source_handover() {
     (.summary != "") and
     (.evidence_refs | type == "array") and
     ((.evidence_refs | length) >= 1) and
-    all(.evidence_refs[]; type == "string") and
+    all(.evidence_refs[]; type == "string" and . != "") and
     (.workspace | type == "string") and
     (.workspace != "") and
     (.verification_status | type == "string") and

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${REPO_ROOT}/lib/core.sh"
+source "${REPO_ROOT}/lib/validate.sh"
 
 OUTPUT_DATE="$(date +"%Y-%m-%d")"
 OUTPUT_DIR="${REPO_ROOT}/reports/evaluation"
@@ -31,7 +33,7 @@ EOF
 
 require_tools() {
   local tool=""
-  for tool in jq cp mkdir; do
+  for tool in jq cp mkdir mktemp; do
     if ! command -v "${tool}" >/dev/null 2>&1; then
       echo "missing required tool: ${tool}" >&2
       exit 1
@@ -127,6 +129,8 @@ validate_source_handover() {
   local json_file="$1"
   local rel_ref="$2"
 
+  validate_handover_bundle "${json_file}" >/dev/null 2>&1 || fail "invalid handover sample: ${rel_ref}"
+
   jq -e '
     type == "object" and
     (.version | type == "number") and
@@ -144,7 +148,7 @@ validate_source_handover() {
     (.workspace | type == "string") and
     (.workspace != "") and
     (.verification_status | type == "string") and
-    (.blocked_by | type == "array")
+    (.verification_status != "")
   ' "${json_file}" >/dev/null 2>&1 || fail "invalid handover sample: ${rel_ref}"
 }
 
@@ -167,18 +171,25 @@ project_tracked_handover() {
 copy_sample_files() {
   local source_dir="$1"
   local target_dir="$2"
+  local target_parent_dir
+  local staging_dir
   local sample=""
 
-  mkdir -p "${target_dir}"
+  target_parent_dir="$(dirname "${target_dir}")"
+  mkdir -p "${target_parent_dir}"
+  staging_dir="$(mktemp -d "${target_parent_dir}/handovers.tmp.XXXXXX")"
 
   for sample in "${SAMPLE_FILES[@]}"; do
     local source_file="${source_dir}/${sample}"
-    local tmp_file="${target_dir}/${sample}.tmp"
+    local tmp_file="${staging_dir}/${sample}.tmp"
     [[ -f "${source_file}" ]] || fail "missing handover sample: ${source_file}"
     validate_source_handover "${source_file}" "${SOURCE_REF_PREFIX}/${sample}"
     project_tracked_handover "${source_file}" > "${tmp_file}"
-    mv "${tmp_file}" "${target_dir}/${sample}"
+    mv "${tmp_file}" "${staging_dir}/${sample}"
   done
+
+  rm -rf "${target_dir}"
+  mv "${staging_dir}" "${target_dir}"
 }
 
 build_summary_json() {

--- a/scripts/phase1_handover_samples.sh
+++ b/scripts/phase1_handover_samples.sh
@@ -148,7 +148,11 @@ validate_source_handover() {
     (.workspace | type == "string") and
     (.workspace != "") and
     (.verification_status | type == "string") and
-    (.verification_status != "")
+    (.verification_status != "") and
+    (if has("blocked_by") then
+      (.blocked_by | type == "array") and
+      all(.blocked_by[]; type == "string" or type == "object")
+    else true end)
   ' "${json_file}" >/dev/null 2>&1 || fail "invalid handover sample: ${rel_ref}"
 }
 
@@ -196,8 +200,11 @@ copy_sample_files() {
     mv "${tmp_file}" "${staging_dir}/${sample}"
   done
 
-  rm -rf "${target_dir}"
-  mv "${staging_dir}" "${target_dir}"
+  mkdir -p "${target_dir}"
+  for sample in "${SAMPLE_FILES[@]}"; do
+    mv "${staging_dir}/${sample}" "${target_dir}/${sample}"
+  done
+  rm -rf "${staging_dir}"
 }
 
 build_summary_json() {

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -321,3 +321,55 @@ handover_samples_defaults_missing_blocked_by_to_empty_array() { # @test
   run jq -e '.blocked_by | type == "array" and length == 0' "${no_blocked_by_output}/handovers/ws-issue10_t2_docs.json"
   [ "$status" -eq 0 ]
 }
+
+handover_samples_resolves_relative_source_dir_from_cwd() { # @test
+  local cwd_source_dir
+  local cwd_output_dir
+  local cwd_json_file
+
+  cwd_source_dir="${SAMPLE_TMPDIR}/cwd-source"
+  cwd_output_dir="${SAMPLE_TMPDIR}/cwd-output"
+  cwd_json_file="${SAMPLE_TMPDIR}/cwd-samples.json"
+
+  mkdir -p "${cwd_source_dir}/handovers"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${cwd_source_dir}/handovers/"
+
+  run bash -lc 'cd "$1" && "$2" --source-dir handovers --output-dir "$3" --date 2026-03-08 > "$4"' _ \
+    "${cwd_source_dir}" "${SAMPLE_SCRIPT}" "${cwd_output_dir}" "${cwd_json_file}"
+  [ "$status" -eq 0 ]
+
+  run jq -e '(.samples | length) >= 3' "${cwd_json_file}"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_rejects_non_integer_version() { # @test
+  local bad_version_dir
+
+  bad_version_dir="${SAMPLE_TMPDIR}/bad-version-source"
+  mkdir -p "${bad_version_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${bad_version_dir}/"
+
+  jq '.version = 2.5' \
+    "${bad_version_dir}/ws-issue10_t2_docs.json" > "${bad_version_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${bad_version_dir}/ws-issue10_t2_docs.json.tmp" "${bad_version_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${bad_version_dir}" --output-dir "${SAMPLE_TMPDIR}/bad-version-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}
+
+handover_samples_rejects_negative_version() { # @test
+  local neg_version_dir
+
+  neg_version_dir="${SAMPLE_TMPDIR}/neg-version-source"
+  mkdir -p "${neg_version_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${neg_version_dir}/"
+
+  jq '.version = -1' \
+    "${neg_version_dir}/ws-issue10_t2_docs.json" > "${neg_version_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${neg_version_dir}/ws-issue10_t2_docs.json.tmp" "${neg_version_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${neg_version_dir}" --output-dir "${SAMPLE_TMPDIR}/neg-version-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -111,6 +111,26 @@ handover_samples_tracked_copies_lock_projected_schema() { # @test
   [ "$status" -eq 0 ]
 }
 
+handover_samples_preserves_full_relative_source_ref() { # @test
+  local relative_json_file
+  local relative_output_dir
+  relative_json_file="${SAMPLE_TMPDIR}/handover-samples-relative.json"
+  relative_output_dir="${SAMPLE_TMPDIR}/reports-relative"
+
+  run bash -lc 'cd "$1" && "$2" --source-dir reports/evaluation/handovers --output-dir "$3" --date 2026-03-08 > "$4"' _ \
+    "${ROOT_DIR}" "${SAMPLE_SCRIPT}" "${relative_output_dir}" "${relative_json_file}"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    [.samples[].source_ref] == [
+      "reports/evaluation/handovers/ws-issue10_t2_docs.json",
+      "reports/evaluation/handovers/ws-issue10_t3_pr.json",
+      "reports/evaluation/handovers/ws-issue10_t6_pr.json"
+    ]
+  ' "${relative_json_file}"
+  [ "$status" -eq 0 ]
+}
+
 handover_samples_matches_checked_in_reports() { # @test
   run jq -S 'del(.generated_at)' "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.json"
   [ "$status" -eq 0 ]

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -6,16 +6,18 @@ setup_file() {
   SAMPLE_TMPDIR="$(mktemp -d)"
   SAMPLE_OUTPUT_DIR="${SAMPLE_TMPDIR}/reports"
   SAMPLE_JSON_FILE="${SAMPLE_TMPDIR}/handover-samples.json"
+  SOURCE_FIXTURE_DIR="${ROOT_DIR}/reports/evaluation/handovers"
   TRACKED_JSON_FILE="${ROOT_DIR}/reports/evaluation/2026-03-08-handover-samples.json"
   TRACKED_MD_FILE="${ROOT_DIR}/reports/evaluation/2026-03-08-handover-samples.md"
 
-  "${SAMPLE_SCRIPT}" --output-dir "${SAMPLE_OUTPUT_DIR}" --date "2026-03-08" > "${SAMPLE_JSON_FILE}"
+  "${SAMPLE_SCRIPT}" --source-dir "${SOURCE_FIXTURE_DIR}" --output-dir "${SAMPLE_OUTPUT_DIR}" --date "2026-03-08" > "${SAMPLE_JSON_FILE}"
 
   export ROOT_DIR
   export SAMPLE_SCRIPT
   export SAMPLE_TMPDIR
   export SAMPLE_OUTPUT_DIR
   export SAMPLE_JSON_FILE
+  export SOURCE_FIXTURE_DIR
   export TRACKED_JSON_FILE
   export TRACKED_MD_FILE
 }
@@ -78,6 +80,34 @@ handover_samples_tracked_copies_exclude_volatile_fields() { # @test
     (has("log") | not) and
     (has("resume_commands") | not)
   ' "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t6_pr.json"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_tracked_copies_match_checked_in_fixtures() { # @test
+  run cmp -s "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t2_docs.json" "${SOURCE_FIXTURE_DIR}/ws-issue10_t2_docs.json"
+  [ "$status" -eq 0 ]
+
+  run cmp -s "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t3_pr.json" "${SOURCE_FIXTURE_DIR}/ws-issue10_t3_pr.json"
+  [ "$status" -eq 0 ]
+
+  run cmp -s "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t6_pr.json" "${SOURCE_FIXTURE_DIR}/ws-issue10_t6_pr.json"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_tracked_copies_lock_projected_schema() { # @test
+  run jq -e '
+    (.version | type == "number") and
+    (.workspace | type == "string") and
+    (.branch | type == "string") and
+    (.agent | type == "string") and
+    (.state | type == "string") and
+    (.summary | type == "string") and
+    (.summary != "") and
+    (.evidence_refs | type == "array") and
+    all(.evidence_refs[]; type == "string") and
+    (.verification_status | type == "string") and
+    (.blocked_by | type == "array")
+  ' "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t2_docs.json"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -301,3 +301,23 @@ handover_samples_rejects_workspace_mismatch() { # @test
   [ "$status" -ne 0 ]
   [[ "${output}" == *"workspace mismatch"* ]]
 }
+
+handover_samples_defaults_missing_blocked_by_to_empty_array() { # @test
+  local no_blocked_by_dir
+  local no_blocked_by_output
+
+  no_blocked_by_dir="${SAMPLE_TMPDIR}/no-blocked-by-source"
+  no_blocked_by_output="${SAMPLE_TMPDIR}/no-blocked-by-output"
+  mkdir -p "${no_blocked_by_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${no_blocked_by_dir}/"
+
+  jq 'del(.blocked_by)' \
+    "${no_blocked_by_dir}/ws-issue10_t2_docs.json" > "${no_blocked_by_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${no_blocked_by_dir}/ws-issue10_t2_docs.json.tmp" "${no_blocked_by_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${no_blocked_by_dir}" --output-dir "${no_blocked_by_output}" --date "2026-03-08"
+  [ "$status" -eq 0 ]
+
+  run jq -e '.blocked_by | type == "array" and length == 0' "${no_blocked_by_output}/handovers/ws-issue10_t2_docs.json"
+  [ "$status" -eq 0 ]
+}

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -420,3 +420,28 @@ handover_samples_preserves_unrelated_files_in_output_dir() { # @test
   [ "$(cat "${preserve_output_dir}/handovers/README.md")" = "keep me" ]
   [ -f "${preserve_output_dir}/handovers/ws-issue10_t2_docs.json" ]
 }
+
+handover_samples_falls_back_when_operational_dir_lacks_samples() { # @test
+  local temp_repo
+  local temp_output_dir
+  local temp_json
+
+  temp_repo="${SAMPLE_TMPDIR}/fallback-empty-maw"
+  temp_output_dir="${SAMPLE_TMPDIR}/fallback-empty-output"
+  temp_json="${SAMPLE_TMPDIR}/fallback-empty.json"
+
+  mkdir -p "${temp_repo}/scripts" "${temp_repo}/lib" "${temp_repo}/reports/evaluation/handovers" "${temp_repo}/.maw/handovers"
+  cp "${SAMPLE_SCRIPT}" "${temp_repo}/scripts/phase1_handover_samples.sh"
+  cp "${ROOT_DIR}/lib/core.sh" "${ROOT_DIR}/lib/validate.sh" "${temp_repo}/lib/"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/reports/evaluation/handovers/"
+  # .maw/handovers exists but is empty — should fall back to reports/evaluation/handovers
+
+  run bash -lc 'cd "$1" && "$2" --output-dir "$3" --date 2026-03-08 > "$4"' _ \
+    "${temp_repo}" "${temp_repo}/scripts/phase1_handover_samples.sh" "${temp_output_dir}" "${temp_json}"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    [.samples[0].source_ref] == ["reports/evaluation/handovers/ws-issue10_t2_docs.json"]
+  ' "${temp_json}"
+  [ "$status" -eq 0 ]
+}

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -373,3 +373,50 @@ handover_samples_rejects_negative_version() { # @test
   [ "$status" -ne 0 ]
   [[ "${output}" == *"invalid handover sample"* ]]
 }
+
+handover_samples_rejects_scalar_blocked_by() { # @test
+  local bad_blocked_dir
+
+  bad_blocked_dir="${SAMPLE_TMPDIR}/bad-blocked-source"
+  mkdir -p "${bad_blocked_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${bad_blocked_dir}/"
+
+  jq '.blocked_by = "oops"' \
+    "${bad_blocked_dir}/ws-issue10_t2_docs.json" > "${bad_blocked_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${bad_blocked_dir}/ws-issue10_t2_docs.json.tmp" "${bad_blocked_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${bad_blocked_dir}" --output-dir "${SAMPLE_TMPDIR}/bad-blocked-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}
+
+handover_samples_rejects_numeric_blocked_by_entries() { # @test
+  local bad_entries_dir
+
+  bad_entries_dir="${SAMPLE_TMPDIR}/bad-entries-source"
+  mkdir -p "${bad_entries_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${bad_entries_dir}/"
+
+  jq '.blocked_by = [42]' \
+    "${bad_entries_dir}/ws-issue10_t2_docs.json" > "${bad_entries_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${bad_entries_dir}/ws-issue10_t2_docs.json.tmp" "${bad_entries_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${bad_entries_dir}" --output-dir "${SAMPLE_TMPDIR}/bad-entries-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}
+
+handover_samples_preserves_unrelated_files_in_output_dir() { # @test
+  local preserve_output_dir
+
+  preserve_output_dir="${SAMPLE_TMPDIR}/preserve-output"
+  mkdir -p "${preserve_output_dir}/handovers"
+  echo "keep me" > "${preserve_output_dir}/handovers/README.md"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${SOURCE_FIXTURE_DIR}" --output-dir "${preserve_output_dir}" --date "2026-03-08"
+  [ "$status" -eq 0 ]
+
+  [ -f "${preserve_output_dir}/handovers/README.md" ]
+  [ "$(cat "${preserve_output_dir}/handovers/README.md")" = "keep me" ]
+  [ -f "${preserve_output_dir}/handovers/ws-issue10_t2_docs.json" ]
+}

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -131,6 +131,35 @@ handover_samples_preserves_full_relative_source_ref() { # @test
   [ "$status" -eq 0 ]
 }
 
+handover_samples_prefers_operational_root_over_tracked_fixtures() { # @test
+  local temp_repo
+  local temp_output_dir
+  local temp_json
+
+  temp_repo="${SAMPLE_TMPDIR}/precedence-repo"
+  temp_output_dir="${SAMPLE_TMPDIR}/precedence-output"
+  temp_json="${SAMPLE_TMPDIR}/precedence.json"
+
+  mkdir -p "${temp_repo}/scripts" "${temp_repo}/reports/evaluation/handovers" "${temp_repo}/.maw/handovers"
+  cp "${SAMPLE_SCRIPT}" "${temp_repo}/scripts/phase1_handover_samples.sh"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/reports/evaluation/handovers/"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/.maw/handovers/"
+
+  jq '.summary = "OPERATIONS-FIRST SAMPLE"' \
+    "${temp_repo}/.maw/handovers/ws-issue10_t2_docs.json" > "${temp_repo}/.maw/handovers/ws-issue10_t2_docs.json.tmp"
+  mv "${temp_repo}/.maw/handovers/ws-issue10_t2_docs.json.tmp" "${temp_repo}/.maw/handovers/ws-issue10_t2_docs.json"
+
+  run bash -lc 'cd "$1" && "$2" --output-dir "$3" --date 2026-03-08 > "$4"' _ \
+    "${temp_repo}" "${temp_repo}/scripts/phase1_handover_samples.sh" "${temp_output_dir}" "${temp_json}"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    [.samples[] | select(.workspace == "issue10_t2_docs") | .summary] == ["OPERATIONS-FIRST SAMPLE"] and
+    [.samples[] | select(.workspace == "issue10_t2_docs") | .source_ref] == [".maw/handovers/ws-issue10_t2_docs.json"]
+  ' "${temp_json}"
+  [ "$status" -eq 0 ]
+}
+
 handover_samples_matches_checked_in_reports() { # @test
   run jq -S 'del(.generated_at)' "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.json"
   [ "$status" -eq 0 ]

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  ROOT_DIR="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  SAMPLE_SCRIPT="${ROOT_DIR}/scripts/phase1_handover_samples.sh"
+  SAMPLE_TMPDIR="$(mktemp -d)"
+  SAMPLE_OUTPUT_DIR="${SAMPLE_TMPDIR}/reports"
+  SAMPLE_JSON_FILE="${SAMPLE_TMPDIR}/handover-samples.json"
+  TRACKED_JSON_FILE="${ROOT_DIR}/reports/evaluation/2026-03-08-handover-samples.json"
+  TRACKED_MD_FILE="${ROOT_DIR}/reports/evaluation/2026-03-08-handover-samples.md"
+
+  "${SAMPLE_SCRIPT}" --output-dir "${SAMPLE_OUTPUT_DIR}" --date "2026-03-08" > "${SAMPLE_JSON_FILE}"
+
+  export ROOT_DIR
+  export SAMPLE_SCRIPT
+  export SAMPLE_TMPDIR
+  export SAMPLE_OUTPUT_DIR
+  export SAMPLE_JSON_FILE
+  export TRACKED_JSON_FILE
+  export TRACKED_MD_FILE
+}
+
+teardown_file() {
+  rm -rf "${SAMPLE_TMPDIR}"
+}
+
+handover_samples_returns_valid_json() { # @test
+  run jq -e 'type == "object" and .version == 1 and .mode == "handover_samples" and (.generated_at | type == "string") and (.samples | type == "array") and (.notes | type == "array")' "${SAMPLE_JSON_FILE}"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_contains_expected_workspaces() { # @test
+  run jq -e '
+    (.samples | length) >= 3 and
+    ([.samples[].workspace] | index("issue10_t2_docs")) != null and
+    ([.samples[].workspace] | index("issue10_t3_pr")) != null and
+    ([.samples[].workspace] | index("issue10_t6_pr")) != null
+  ' "${SAMPLE_JSON_FILE}"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_enforces_summary_and_evidence_refs() { # @test
+  run jq -e 'all(.samples[]; (.summary != "") and (.evidence_refs_count >= 1))' "${SAMPLE_JSON_FILE}"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_writes_json_and_markdown_reports() { # @test
+  [ -f "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.json" ]
+  [ -f "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.md" ]
+  [ -f "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t2_docs.json" ]
+  [ -f "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t3_pr.json" ]
+  [ -f "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t6_pr.json" ]
+}
+
+handover_samples_tracked_copies_exclude_volatile_fields() { # @test
+  run jq -e '
+    (has("claims") | not) and
+    (has("diff") | not) and
+    (has("diff_stat") | not) and
+    (has("log") | not) and
+    (has("resume_commands") | not)
+  ' "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t2_docs.json"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    (has("claims") | not) and
+    (has("diff") | not) and
+    (has("diff_stat") | not) and
+    (has("log") | not) and
+    (has("resume_commands") | not)
+  ' "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t3_pr.json"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    (has("claims") | not) and
+    (has("diff") | not) and
+    (has("diff_stat") | not) and
+    (has("log") | not) and
+    (has("resume_commands") | not)
+  ' "${SAMPLE_OUTPUT_DIR}/handovers/ws-issue10_t6_pr.json"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_matches_checked_in_reports() { # @test
+  run jq -S 'del(.generated_at)' "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.json"
+  [ "$status" -eq 0 ]
+  local generated_json="$output"
+
+  run jq -S 'del(.generated_at)' "${TRACKED_JSON_FILE}"
+  [ "$status" -eq 0 ]
+  local tracked_json="$output"
+
+  [ "${generated_json}" = "${tracked_json}" ]
+
+  run cmp -s "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.md" "${TRACKED_MD_FILE}"
+  [ "$status" -eq 0 ]
+}

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -160,6 +160,53 @@ handover_samples_prefers_operational_root_over_tracked_fixtures() { # @test
   [ "$status" -eq 0 ]
 }
 
+handover_samples_ignores_parent_maw_when_repo_root_has_no_operational_samples() { # @test
+  local parent_dir
+  local temp_repo
+  local temp_output_dir
+  local temp_json
+
+  parent_dir="${SAMPLE_TMPDIR}/outer"
+  temp_repo="${parent_dir}/repo"
+  temp_output_dir="${SAMPLE_TMPDIR}/fallback-output"
+  temp_json="${SAMPLE_TMPDIR}/fallback.json"
+
+  mkdir -p "${parent_dir}/.maw/handovers" "${temp_repo}/scripts" "${temp_repo}/reports/evaluation/handovers"
+  cp "${SAMPLE_SCRIPT}" "${temp_repo}/scripts/phase1_handover_samples.sh"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/reports/evaluation/handovers/"
+  cp "${SOURCE_FIXTURE_DIR}/ws-issue10_t2_docs.json" "${parent_dir}/.maw/handovers/ws-issue10_t2_docs.json"
+
+  jq '.summary = "UNRELATED PARENT SAMPLE"' \
+    "${parent_dir}/.maw/handovers/ws-issue10_t2_docs.json" > "${parent_dir}/.maw/handovers/ws-issue10_t2_docs.json.tmp"
+  mv "${parent_dir}/.maw/handovers/ws-issue10_t2_docs.json.tmp" "${parent_dir}/.maw/handovers/ws-issue10_t2_docs.json"
+
+  run bash -lc 'cd "$1" && "$2" --output-dir "$3" --date 2026-03-08 > "$4"' _ \
+    "${temp_repo}" "${temp_repo}/scripts/phase1_handover_samples.sh" "${temp_output_dir}" "${temp_json}"
+  [ "$status" -eq 0 ]
+
+  run jq -e '
+    [.samples[] | select(.workspace == "issue10_t2_docs") | .summary] == ["Issue 10 T2 docs: fixed the public doctor --json contract in commands and CI docs, including a new English doctor-ci guide"] and
+    [.samples[] | select(.workspace == "issue10_t2_docs") | .source_ref] == ["reports/evaluation/handovers/ws-issue10_t2_docs.json"]
+  ' "${temp_json}"
+  [ "$status" -eq 0 ]
+}
+
+handover_samples_rejects_empty_evidence_refs_entries() { # @test
+  local invalid_source_dir
+
+  invalid_source_dir="${SAMPLE_TMPDIR}/invalid-source"
+  mkdir -p "${invalid_source_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${invalid_source_dir}/"
+
+  jq '.evidence_refs = [""]' \
+    "${invalid_source_dir}/ws-issue10_t2_docs.json" > "${invalid_source_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${invalid_source_dir}/ws-issue10_t2_docs.json.tmp" "${invalid_source_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${invalid_source_dir}" --output-dir "${SAMPLE_TMPDIR}/invalid-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}
+
 handover_samples_matches_checked_in_reports() { # @test
   run jq -S 'del(.generated_at)' "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.json"
   [ "$status" -eq 0 ]

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -140,8 +140,9 @@ handover_samples_prefers_operational_root_over_tracked_fixtures() { # @test
   temp_output_dir="${SAMPLE_TMPDIR}/precedence-output"
   temp_json="${SAMPLE_TMPDIR}/precedence.json"
 
-  mkdir -p "${temp_repo}/scripts" "${temp_repo}/reports/evaluation/handovers" "${temp_repo}/.maw/handovers"
+  mkdir -p "${temp_repo}/scripts" "${temp_repo}/lib" "${temp_repo}/reports/evaluation/handovers" "${temp_repo}/.maw/handovers"
   cp "${SAMPLE_SCRIPT}" "${temp_repo}/scripts/phase1_handover_samples.sh"
+  cp "${ROOT_DIR}/lib/core.sh" "${ROOT_DIR}/lib/validate.sh" "${temp_repo}/lib/"
   cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/reports/evaluation/handovers/"
   cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/.maw/handovers/"
 
@@ -171,8 +172,9 @@ handover_samples_ignores_parent_maw_when_repo_root_has_no_operational_samples() 
   temp_output_dir="${SAMPLE_TMPDIR}/fallback-output"
   temp_json="${SAMPLE_TMPDIR}/fallback.json"
 
-  mkdir -p "${parent_dir}/.maw/handovers" "${temp_repo}/scripts" "${temp_repo}/reports/evaluation/handovers"
+  mkdir -p "${parent_dir}/.maw/handovers" "${temp_repo}/scripts" "${temp_repo}/lib" "${temp_repo}/reports/evaluation/handovers"
   cp "${SAMPLE_SCRIPT}" "${temp_repo}/scripts/phase1_handover_samples.sh"
+  cp "${ROOT_DIR}/lib/core.sh" "${ROOT_DIR}/lib/validate.sh" "${temp_repo}/lib/"
   cp "${SOURCE_FIXTURE_DIR}/"*.json "${temp_repo}/reports/evaluation/handovers/"
   cp "${SOURCE_FIXTURE_DIR}/ws-issue10_t2_docs.json" "${parent_dir}/.maw/handovers/ws-issue10_t2_docs.json"
 
@@ -205,6 +207,49 @@ handover_samples_rejects_empty_evidence_refs_entries() { # @test
   run "${SAMPLE_SCRIPT}" --source-dir "${invalid_source_dir}" --output-dir "${SAMPLE_TMPDIR}/invalid-output" --date "2026-03-08"
   [ "$status" -ne 0 ]
   [[ "${output}" == *"invalid handover sample"* ]]
+}
+
+handover_samples_rejects_noncanonical_handover_fields() { # @test
+  local invalid_source_dir
+
+  invalid_source_dir="${SAMPLE_TMPDIR}/invalid-canonical-source"
+  mkdir -p "${invalid_source_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${invalid_source_dir}/"
+
+  jq '.verification_status = "done" | .blocked_by = [{"type":"dependency","description":"missing resolved"}]' \
+    "${invalid_source_dir}/ws-issue10_t2_docs.json" > "${invalid_source_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${invalid_source_dir}/ws-issue10_t2_docs.json.tmp" "${invalid_source_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${invalid_source_dir}" --output-dir "${SAMPLE_TMPDIR}/invalid-canonical-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}
+
+handover_samples_does_not_partially_overwrite_outputs_on_invalid_source() { # @test
+  local invalid_source_dir
+  local stable_output_dir
+
+  invalid_source_dir="${SAMPLE_TMPDIR}/partial-invalid-source"
+  stable_output_dir="${SAMPLE_TMPDIR}/partial-output"
+  mkdir -p "${invalid_source_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${invalid_source_dir}/"
+
+  "${SAMPLE_SCRIPT}" --source-dir "${SOURCE_FIXTURE_DIR}" --output-dir "${stable_output_dir}" --date "2026-03-08" > /dev/null
+
+  jq '.summary = "SHOULD NOT LAND"' \
+    "${invalid_source_dir}/ws-issue10_t2_docs.json" > "${invalid_source_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${invalid_source_dir}/ws-issue10_t2_docs.json.tmp" "${invalid_source_dir}/ws-issue10_t2_docs.json"
+  jq '.summary = ""' \
+    "${invalid_source_dir}/ws-issue10_t3_pr.json" > "${invalid_source_dir}/ws-issue10_t3_pr.json.tmp"
+  mv "${invalid_source_dir}/ws-issue10_t3_pr.json.tmp" "${invalid_source_dir}/ws-issue10_t3_pr.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${invalid_source_dir}" --output-dir "${stable_output_dir}" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+
+  run jq -r '.summary' "${stable_output_dir}/handovers/ws-issue10_t2_docs.json"
+  [ "$status" -eq 0 ]
+  [ "${output}" = "Issue 10 T2 docs: fixed the public doctor --json contract in commands and CI docs, including a new English doctor-ci guide" ]
 }
 
 handover_samples_matches_checked_in_reports() { # @test

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -445,3 +445,19 @@ handover_samples_falls_back_when_operational_dir_lacks_samples() { # @test
   ' "${temp_json}"
   [ "$status" -eq 0 ]
 }
+
+handover_samples_rejects_v1_bundles() { # @test
+  local v1_source_dir
+
+  v1_source_dir="${SAMPLE_TMPDIR}/v1-source"
+  mkdir -p "${v1_source_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${v1_source_dir}/"
+
+  jq '.version = 1' \
+    "${v1_source_dir}/ws-issue10_t2_docs.json" > "${v1_source_dir}/ws-issue10_t2_docs.json.tmp"
+  mv "${v1_source_dir}/ws-issue10_t2_docs.json.tmp" "${v1_source_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${v1_source_dir}" --output-dir "${SAMPLE_TMPDIR}/v1-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"invalid handover sample"* ]]
+}

--- a/tests/handover_samples_test.bats
+++ b/tests/handover_samples_test.bats
@@ -266,3 +266,38 @@ handover_samples_matches_checked_in_reports() { # @test
   run cmp -s "${SAMPLE_OUTPUT_DIR}/2026-03-08-handover-samples.md" "${TRACKED_MD_FILE}"
   [ "$status" -eq 0 ]
 }
+
+handover_samples_preserves_full_absolute_source_ref() { # @test
+  local abs_source_dir
+  local abs_output_dir
+  local abs_json_file
+
+  abs_source_dir="${SAMPLE_TMPDIR}/abs-source"
+  abs_output_dir="${SAMPLE_TMPDIR}/abs-output"
+  abs_json_file="${SAMPLE_TMPDIR}/abs-samples.json"
+
+  mkdir -p "${abs_source_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${abs_source_dir}/"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${abs_source_dir}" --output-dir "${abs_output_dir}" --date "2026-03-08"
+  [ "$status" -eq 0 ]
+
+  run jq -r '.samples[0].source_ref' "${abs_output_dir}/2026-03-08-handover-samples.json"
+  [ "$status" -eq 0 ]
+  [[ "${output}" == "${abs_source_dir}/ws-issue10_t2_docs.json" ]]
+}
+
+handover_samples_rejects_workspace_mismatch() { # @test
+  local mismatch_source_dir
+
+  mismatch_source_dir="${SAMPLE_TMPDIR}/mismatch-source"
+  mkdir -p "${mismatch_source_dir}"
+  cp "${SOURCE_FIXTURE_DIR}/"*.json "${mismatch_source_dir}/"
+
+  # Copy t3 payload into t2 slot
+  cp "${SOURCE_FIXTURE_DIR}/ws-issue10_t3_pr.json" "${mismatch_source_dir}/ws-issue10_t2_docs.json"
+
+  run "${SAMPLE_SCRIPT}" --source-dir "${mismatch_source_dir}" --output-dir "${SAMPLE_TMPDIR}/mismatch-output" --date "2026-03-08"
+  [ "$status" -ne 0 ]
+  [[ "${output}" == *"workspace mismatch"* ]]
+}


### PR DESCRIPTION
## Summary
- add `scripts/phase1_handover_samples.sh` to promote operational handover bundles into tracked evaluation artifacts
- add pinned tracked sample projections under `reports/evaluation/handovers/`
- add `tests/handover_samples_test.bats` to lock summary/evidence_refs coverage and checked-in report parity

## Verification
- `bash -n scripts/phase1_handover_samples.sh`
- `git diff --check`
- `timeout 180 bats tests/handover_samples_test.bats`
- `timeout 180 bats tests/metrics_test.bats`
- `timeout 180 bats tests/additional_scenarios_test.bats`
- `scripts/phase1_handover_samples.sh`
- `scripts/phase1_handover_samples.sh --output-dir "$(mktemp -d)" --date 2026-03-08`

## Notes
- The tracked sample copies are stable projections and intentionally exclude volatile fields such as `claims`, raw logs, raw diffs, and `resume_commands`.
- Follow-up risk from review: the current script/test still rely on local root `.maw/handovers` state rather than hermetic committed fixtures, and source validation does not yet fully lock every projected field type.
- Refs A-003